### PR TITLE
Create tests surrounding list metadata formats [ch91]

### DIFF
--- a/test/integration/expect_args_test.rb
+++ b/test/integration/expect_args_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class NavigationTest < ActionDispatch::IntegrationTest
+class ExpectArgsTest < ActionDispatch::IntegrationTest
 
   include Oaisys::Engine.routes.url_helpers
 

--- a/test/integration/list_metadata_formats_test.rb
+++ b/test/integration/list_metadata_formats_test.rb
@@ -16,17 +16,24 @@ class ListMetadataFormatsTest < ActionDispatch::IntegrationTest
     document = Nokogiri::XML(@response.body)
     assert_empty schema.validate(document)
 
-    supported_formats = Oaisys::PMHController::SUPPORTED_FORMATS
     assert_select 'OAI-PMH' do
       assert_select 'responseDate'
       assert_select 'request'
       assert_select 'ListMetadataFormats' do
-        supported_formats.each do |supported_format|
-          assert_select 'metadataFormat' do
-            assert_select 'metadataPrefix', supported_format[:metadataPrefix]
-            assert_select 'schema', supported_format[:schema]
-            assert_select 'metadataNamespace', supported_format[:metadataNamespace]
-          end
+        assert_select 'metadataFormat' do
+          assert_select 'metadataPrefix', 'oai_dc'
+          assert_select 'schema', 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd'
+          assert_select 'metadataNamespace', 'http://www.openarchives.org/OAI/2.0/oai_dc/'
+        end
+        assert_select 'metadataFormat' do
+          assert_select 'metadataPrefix', 'oai_etdms'
+          assert_select 'schema', 'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd'
+          assert_select 'metadataNamespace', 'http://www.ndltd.org/standards/metadata/etdms/1.0/'
+        end
+        assert_select 'metadataFormat' do
+          assert_select 'metadataPrefix', 'ore'
+          assert_select 'schema', 'http://www.kbcafe.com/rss/atom.xsd.xml'
+          assert_select 'metadataNamespace', 'http://www.w3.org/2005/Atom'
         end
       end
     end

--- a/test/integration/list_metadata_formats_test.rb
+++ b/test/integration/list_metadata_formats_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class ListMetadataFormatsTest < ActionDispatch::IntegrationTest
+
+  include Oaisys::Engine.routes.url_helpers
+
+  setup do
+    @routes = Oaisys::Engine.routes
+  end
+
+  def test_list_metadata_formats_xml
+    get oaisys_path + '?verb=ListMetadataFormats', headers: { 'Accept' => 'application/xml' }
+    assert_response :success
+
+    schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))
+    document = Nokogiri::XML(@response.body)
+    assert_empty schema.validate(document)
+
+    supported_formats = Oaisys::PMHController::SUPPORTED_FORMATS
+    assert_select 'OAI-PMH' do
+      assert_select 'responseDate'
+      assert_select 'request'
+      assert_select 'ListMetadataFormats' do
+        supported_formats.each do |supported_format|
+          assert_select 'metadataFormat' do
+            assert_select 'metadataPrefix', supported_format[:metadataPrefix]
+            assert_select 'schema', supported_format[:schema]
+            assert_select 'metadataNamespace', supported_format[:metadataNamespace]
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Context

need tests surrounding list_metadata_formats response

Related to # ch91
## What's New

Tests have been added surrounding the response and xml and the class name for expect_args_test has been fixed