### PR TITLE
Create tests surrounding Identify verb [ch98]

### DIFF
--- a/test/fixtures/files/OAI-PMH.xsd
+++ b/test/fixtures/files/OAI-PMH.xsd
@@ -1,10 +1,10 @@
-
 <schema targetNamespace="http://www.openarchives.org/OAI/2.0/"
         xmlns="http://www.w3.org/2001/XMLSchema"
         xmlns:oai="http://www.openarchives.org/OAI/2.0/"
         elementFormDefault="qualified"
         attributeFormDefault="unqualified">
 
+  <import schemaLocation="oai-identifier.xsd"/>
   <annotation>
     <documentation>
       XML Schema which can be used to validate replies to all OAI-PMH

--- a/test/fixtures/files/oai-identifier.xsd
+++ b/test/fixtures/files/oai-identifier.xsd
@@ -1,0 +1,47 @@
+<schema targetNamespace="http://www.openarchives.org/OAI/2.0/oai-identifier"
+        xmlns:oai-identifier="http://www.openarchives.org/OAI/2.0/oai-identifier"
+        xmlns="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified">
+
+  <annotation>
+    <documentation>
+      Schema for description section of Identify reply of OAI-PMH v2.0.
+      For repositories that comply with the oai format for unique identifiers
+      for items records.
+      See: http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
+      Validated with http://www.w3.org/2001/03/webdata/xsv on 2002-05-16
+      Corrected to handle single letter elements in domain name, e.g ebibpol.p.lodz.pl 2007-05-22
+      Simeon Warner $Date: 2007-06-07 19:28:11 $
+    </documentation>
+  </annotation>
+
+  <element name="oai-identifier" type="oai-identifier:oai-identifierType"/>
+
+  <complexType name="oai-identifierType">
+    <sequence>
+      <element name="scheme" minOccurs="1" maxOccurs="1"
+               type="string" fixed="oai"/>
+      <element name="repositoryIdentifier" minOccurs="1" maxOccurs="1"
+               type="oai-identifier:repositoryIdentifierType"/>
+      <element name="delimiter" minOccurs="1" maxOccurs="1"
+               type="string" fixed=":"/>
+      <element name="sampleIdentifier" minOccurs="1" maxOccurs="1"
+               type="oai-identifier:sampleIdentifierType"/>
+    </sequence>
+  </complexType>
+
+  <simpleType name="repositoryIdentifierType">
+    <restriction base="string">
+      <pattern value="[a-zA-Z][a-zA-Z0-9\-]*(\.[a-zA-Z][a-zA-Z0-9\-]*)+"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="sampleIdentifierType">
+    <restriction base="string">
+      <pattern value="oai:[a-zA-Z][a-zA-Z0-9\-]*(\.[a-zA-Z][a-zA-Z0-9\-]*)+:[a-zA-Z0-9\-_\.!~\*&apos;\(\);/\?:@&amp;=\+$,%]+"/>
+      <!--meta ., \, ?, *, +, {, } (, ), [ or ] -->
+    </restriction>
+  </simpleType>
+
+</schema>

--- a/test/integration/expect_args_test.rb
+++ b/test/integration/expect_args_test.rb
@@ -9,7 +9,7 @@ class ExpectArgsTest < ActionDispatch::IntegrationTest
   end
 
   def test_unexpected_arg_xml
-    get oaisys_path + '?verb=ListMetadataFormats&nastyParam=nasty', headers: { 'Accept' => 'application/xml' }
+    get oaisys_path(verb: 'ListMetadataFormats', nastyParam: 'nasty'), headers: { 'Accept' => 'application/xml' }
     assert_response :success
 
     schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))
@@ -25,7 +25,7 @@ class ExpectArgsTest < ActionDispatch::IntegrationTest
 
   def test_missing_required_arg_xml
     # Missing required metadataPrefix param
-    get oaisys_path + '?verb=ListRecords', headers: { 'Accept' => 'application/xml' }
+    get oaisys_path(verb: 'ListRecords'), headers: { 'Accept' => 'application/xml' }
     assert_response :success
 
     schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))

--- a/test/integration/identify_test.rb
+++ b/test/integration/identify_test.rb
@@ -9,7 +9,7 @@ class IdentifyTest < ActionDispatch::IntegrationTest
   end
 
   def test_identify_xml
-    get oaisys_path + '?verb=Identify', headers: { 'Accept' => 'application/xml' }
+    get oaisys_path(verb: 'Identify'), headers: { 'Accept' => 'application/xml' }
     assert_response :success
 
     schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))

--- a/test/integration/identify_test.rb
+++ b/test/integration/identify_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class IdentifyTest < ActionDispatch::IntegrationTest
+
+  include Oaisys::Engine.routes.url_helpers
+
+  setup do
+    @routes = Oaisys::Engine.routes
+  end
+
+  def test_identify_xml
+    get oaisys_path + '?verb=Identify', headers: { 'Accept' => 'application/xml' }
+    assert_response :success
+
+    schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))
+    document = Nokogiri::XML(@response.body)
+    assert_empty schema.validate(document)
+
+    assert_select 'OAI-PMH' do
+      assert_select 'responseDate'
+      assert_select 'request', 'https://era.library.ualberta.ca/oai'
+      assert_select 'Identify' do
+        assert_select 'repositoryName', 'ERA: Education and Research Archive'
+        assert_select 'baseURL', 'https://era.library.ualberta.ca/oai'
+        assert_select 'protocolVersion', '2.0'
+        assert_select 'adminEmail', 'eraadmi@ualberta.ca'
+        assert_select 'earliestDatestamp'
+        assert_select 'deletedRecord', 'no'
+        assert_select 'granularity', 'YYYY-MM-DDThh:mm:ssZ'
+        assert_select 'description' do
+          assert_select 'oai-id|oai-identifier' do
+            assert_select 'oai-id|scheme', 'oai'
+            assert_select 'oai-id|repositoryIdentifier', 'era.library.ualberta.ca'
+            assert_select 'oai-id|delimiter', ':'
+            assert_select 'oai-id|sampleIdentifier', 'oai:era.library.ualberta.ca:1d7047d8-f164-45bb-b62c-ae6045eb0c42'
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/test/integration/list_metadata_formats_test.rb
+++ b/test/integration/list_metadata_formats_test.rb
@@ -9,7 +9,7 @@ class ListMetadataFormatsTest < ActionDispatch::IntegrationTest
   end
 
   def test_list_metadata_formats_xml
-    get oaisys_path + '?verb=ListMetadataFormats', headers: { 'Accept' => 'application/xml' }
+    get oaisys_path(verb: 'ListMetadataFormats'), headers: { 'Accept' => 'application/xml' }
     assert_response :success
 
     schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))

--- a/test/integration/list_metadata_formats_test.rb
+++ b/test/integration/list_metadata_formats_test.rb
@@ -18,7 +18,7 @@ class ListMetadataFormatsTest < ActionDispatch::IntegrationTest
 
     assert_select 'OAI-PMH' do
       assert_select 'responseDate'
-      assert_select 'request'
+      assert_select 'request', 'https://era.library.ualberta.ca/oai'
       assert_select 'ListMetadataFormats' do
         assert_select 'metadataFormat' do
           assert_select 'metadataPrefix', 'oai_dc'


### PR DESCRIPTION
## Context

Need tests surrounding Identify verb

Related to ch98

## What's New

Added new schema and imported it from main schema. Added tests for identify verb. Added missing check in list_metadata_formats_test.rb and removed empty line in OAI-PMH.xsd.