### PR TITLE
Verb ListIdentifiers [ch101]

### DIFF
--- a/app/controllers/oaisys/application_controller.rb
+++ b/app/controllers/oaisys/application_controller.rb
@@ -1,6 +1,17 @@
 # TODO: Extending off base rather than api because render wouldn't find views, look into another way to resolve this.
 class Oaisys::ApplicationController < ActionController::Base
 
+  rescue_from 'ActionController::UnpermittedParameters', 'ActionController::ParameterMissing' do
+    respond_to do |format|
+      format.xml do
+        render :error, locals: {
+          parameters: params.to_unsafe_h.slice(:verb), error_code: :badArgument,
+          error_message: I18n.t('error_messages.illegal_or_missing_arguments')
+        }
+      end
+    end
+  end
+
   # protect_from_forgery with: :exception
   rescue_from 'Oaisys::PMHError' do |exception|
     respond_to do |format|

--- a/app/controllers/oaisys/application_controller.rb
+++ b/app/controllers/oaisys/application_controller.rb
@@ -5,7 +5,7 @@ class Oaisys::ApplicationController < ActionController::Base
     respond_to do |format|
       format.xml do
         render :error, locals: {
-          # Being unsafe by using to_unsafe_h here because calling .pernit will throw this error again.
+          # Being unsafe by using to_unsafe_h here because calling .permit will throw this error again.
           parameters: params.to_unsafe_h.slice(:verb), error_code: :badArgument,
           error_message: I18n.t('error_messages.illegal_or_missing_arguments')
         }

--- a/app/controllers/oaisys/application_controller.rb
+++ b/app/controllers/oaisys/application_controller.rb
@@ -5,6 +5,7 @@ class Oaisys::ApplicationController < ActionController::Base
     respond_to do |format|
       format.xml do
         render :error, locals: {
+          # Being unsafe by using to_unsafe_h here because calling .pernit will throw this error again.
           parameters: params.to_unsafe_h.slice(:verb), error_code: :badArgument,
           error_message: I18n.t('error_messages.illegal_or_missing_arguments')
         }

--- a/app/controllers/oaisys/application_controller.rb
+++ b/app/controllers/oaisys/application_controller.rb
@@ -6,7 +6,7 @@ class Oaisys::ApplicationController < ActionController::Base
     respond_to do |format|
       format.xml do
         render :error, locals: {
-          verb: exception.for_verb, error_code: exception.error_code, error_message: exception.error_message
+          parameters: exception.parameters, error_code: exception.error_code, error_message: exception.error_message
         }
       end
     end

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -17,59 +17,73 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   def bad_verb; end
 
   def identify
-    expect_no_args for_verb: :Identify
-
     respond_to do |format|
       format.xml { render :identify }
     end
   end
 
   def list_sets
-    expect_args for_verb: :ListSets, exclusive: [:resumptionToken]
+    expect_args exclusive: [:resumptionToken]
   end
 
   # TODO: Handle the identifier argument.
   def list_metadata_formats
-    expect_args for_verb: :ListMetadataFormats, optional: [:identifier]
+    expect_args optional: [:identifier]
 
+    parameters = params.except('controller', 'action')
     respond_to do |format|
       format.xml do
-        render :list_metadata_formats, locals: { supported_formats: SUPPORTED_FORMATS }
+        render :list_metadata_formats, locals: { supported_formats: SUPPORTED_FORMATS, parameters: parameters }
       end
     end
   end
 
   def list_records
-    expect_args for_verb: :ListRecords, required: [:metadataPrefix], optional: [:from, :until, :set],
-                exclusive: [:resumptionToken]
+    expect_args required: [:metadataPrefix], optional: [:from, :until, :set], exclusive: [:resumptionToken]
   end
 
   # get_record is referring to the verb, not a getter.
   # rubocop:disable Naming/AccessorMethodName
   def get_record
-    expect_args for_verb: :GetRecord, required: [:identifier, :metadataPrefix]
+    expect_args required: [:identifier, :metadataPrefix]
   end
   # rubocop:enable Naming/AccessorMethodName
 
+  # TODO: Handle from, until, and resumptionToken arguments.
   def list_identifiers
-    expect_args for_verb: :ListIdentifiers, required: [:metadataPrefix], optional: [:from, :until, :set],
-                exclusive: [:resumptionToken]
+    expect_args required: [:metadataPrefix], optional: [:from, :until, :set], exclusive: [:resumptionToken]
+
+    parameters = params.except('controller', 'action').to_unsafe_h
+    metadata_prefix = params[:metadataPrefix]
+    if metadata_prefix == 'oai_dc'
+      results = Oaisys::Engine.config.oai_dc_model.where(visibility: JupiterCore::VISIBILITY_PUBLIC)
+    elsif metadata_prefix == 'oai_etdms'
+      results = Oaisys::Engine.config.oai_etdms_model.where(visibility: JupiterCore::VISIBILITY_PUBLIC)
+    else
+      parameters = params.to_unsafe_h.slice(:verb, :metadataPrefix)
+      raise Oaisys::CannotDisseminateFormatError.new(parameters: parameters)
+    end
+
+    results = results.where("member_of_paths": params[:set].tr(':', '/')) if params[:set].present?
+    raise Oaisys::NoRecordsMatchError.new(parameters: parameters) if results.empty?
+
+    respond_to do |format|
+      format.xml do
+        render :list_identifiers, locals: { results: results, parameters: parameters }
+      end
+    end
   end
 
   private
 
-  def expect_args(for_verb:, required: [], optional: [], exclusive: [])
+  def expect_args(required: [], optional: [], exclusive: [])
     arguments = params.except('verb', 'controller', 'action').keys.map(&:to_sym)
     expected_verb_arguments = required + optional + exclusive
     unexpected_arguments = (arguments - expected_verb_arguments).present?
     missing_required_arguments = (required - arguments).present?
 
-    raise Oaisys::BadArgumentError.new(for_verb: for_verb) if unexpected_arguments || missing_required_arguments
-  end
-
-  # Conventional way of calling expect_args for a verb with no arguments.
-  def expect_no_args(for_verb:)
-    expect_args(for_verb: for_verb)
+    parameters = params.to_unsafe_h.slice(:verb)
+    raise Oaisys::BadArgumentError.new(parameters: parameters) if unexpected_arguments || missing_required_arguments
   end
 
 end

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -30,10 +30,9 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   def list_metadata_formats
     expect_args optional: [:identifier]
 
-    parameters = params.except('controller', 'action')
     respond_to do |format|
       format.xml do
-        render :list_metadata_formats, locals: { supported_formats: SUPPORTED_FORMATS, parameters: parameters }
+        render :list_metadata_formats, locals: { supported_formats: SUPPORTED_FORMATS, parameters: @parameters }
       end
     end
   end
@@ -53,23 +52,20 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   def list_identifiers
     expect_args required: [:metadataPrefix], optional: [:from, :until, :set], exclusive: [:resumptionToken]
 
-    parameters = params.except('controller', 'action').to_unsafe_h
     metadata_prefix = params[:metadataPrefix]
     if metadata_prefix == 'oai_dc'
-      results = Oaisys::Engine.config.oai_dc_model.where(visibility: JupiterCore::VISIBILITY_PUBLIC)
+      results = Oaisys::Engine.config.oai_dc_model.public_items
     elsif metadata_prefix == 'oai_etdms'
-      results = Oaisys::Engine.config.oai_etdms_model.where(visibility: JupiterCore::VISIBILITY_PUBLIC)
+      results = Oaisys::Engine.config.oai_etdms_model.public_items
     else
-      parameters = params.to_unsafe_h.slice(:verb, :metadataPrefix)
-      raise Oaisys::CannotDisseminateFormatError.new(parameters: parameters)
+      raise Oaisys::CannotDisseminateFormatError.new(parameters: @parameters.slice(:verb, :metadataPrefix))
     end
-
-    results = results.where("member_of_paths": params[:set].tr(':', '/')) if params[:set].present?
-    raise Oaisys::NoRecordsMatchError.new(parameters: parameters) if results.empty?
+    results = results.belongs_to_set(params[:set].tr(':', '/')) if params[:set].present?
+    raise Oaisys::NoRecordsMatchError.new(parameters: @parameters.slice(:verb, :metadataPrefix)) if results.empty?
 
     respond_to do |format|
       format.xml do
-        render :list_identifiers, locals: { results: results, parameters: parameters }
+        render :list_identifiers, locals: { results: results, parameters: @parameters }
       end
     end
   end
@@ -82,8 +78,10 @@ class Oaisys::PMHController < Oaisys::ApplicationController
     unexpected_arguments = (arguments - expected_verb_arguments).present?
     missing_required_arguments = (required - arguments).present?
 
-    parameters = params.to_unsafe_h.slice(:verb)
-    raise Oaisys::BadArgumentError.new(parameters: parameters) if unexpected_arguments || missing_required_arguments
+    @parameters = params.permit([:verb] + required + optional + exclusive).to_h
+    return unless unexpected_arguments || missing_required_arguments
+
+    raise Oaisys::BadArgumentError.new(parameters: @parameters.slice(:verb))
   end
 
 end

--- a/app/helpers/oaisys/error_helper.rb
+++ b/app/helpers/oaisys/error_helper.rb
@@ -1,0 +1,31 @@
+module Oaisys::ErrorHelper
+  def error_header(error_code)
+    if error_code == :badArgument
+      { 'xmlns': 'http://www.openarchives.org/OAI/2.0/',
+        'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+        'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
+                              'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd' }
+    else
+      { 'xmlns:dc': 'http://purl.org/dc/elements/1.1/',
+        'xmlns:oai-id': 'http://www.openarchives.org/OAI/2.0/oai-identifier',
+        'xmlns': 'http://www.openarchives.org/OAI/2.0/',
+        'xmlns:etd_ms': 'http://www.ndltd.org/standards/metadata/etdms/1.0/',
+        'xmlns:atom': 'http://www.w3.org/2005/Atom',
+        'xmlns:rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+        'xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        'xmlns:dcterms': 'http://purl.org/dc/terms/',
+        'xmlns:oreatom': 'http://www.openarchives.org/ore/atom/',
+        'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+        'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+        'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
+        'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd '\
+        'http://www.openarchives.org/OAI/2.0/oai-identifier '\
+        'http://www.openarchives.org/OAI/2.0/oai-identifier.xsd '\
+        'http://www.openarchives.org/OAI/2.0/oai_dc/ '\
+        'http://www.openarchives.org/OAI/2.0/oai_dc.xsd '\
+        'http://www.ndltd.org/standards/metadata/etdms/1.0/ '\
+        'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
+        'http://www.w3.org/2005/Atom' }
+    end
+  end
+end

--- a/app/views/oaisys/pmh/error.xml.builder
+++ b/app/views/oaisys/pmh/error.xml.builder
@@ -1,7 +1,30 @@
-xml.push_deferred_attribute('xmlns': 'http://www.openarchives.org/OAI/2.0/',
-                            'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-                            'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
-                            'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd')
+if error_code == :badArgument
+  xml.push_deferred_attribute('xmlns': 'http://www.openarchives.org/OAI/2.0/',
+                              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                              'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
+                              'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd')
+else
+  xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
+                              'xmlns:oai-id': 'http://www.openarchives.org/OAI/2.0/oai-identifier',
+                              'xmlns': 'http://www.openarchives.org/OAI/2.0/',
+                              'xmlns:etd_ms': 'http://www.ndltd.org/standards/metadata/etdms/1.0/',
+                              'xmlns:atom': 'http://www.w3.org/2005/Atom',
+                              'xmlns:rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+                              'xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+                              'xmlns:dcterms': 'http://purl.org/dc/terms/',
+                              'xmlns:oreatom': 'http://www.openarchives.org/ore/atom/',
+                              'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+                              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                              'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
+                              'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd '\
+                              'http://www.openarchives.org/OAI/2.0/oai-identifier '\
+                              'http://www.openarchives.org/OAI/2.0/oai-identifier.xsd '\
+                              'http://www.openarchives.org/OAI/2.0/oai_dc/ '\
+                              'http://www.openarchives.org/OAI/2.0/oai_dc.xsd '\
+                              'http://www.ndltd.org/standards/metadata/etdms/1.0/ '\
+                              'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
+                              'http://www.w3.org/2005/Atom')
+end
 
-xml.request(verb: verb)
+xml.tag!('request', parameters)
 xml.error(error_message, code: error_code)

--- a/app/views/oaisys/pmh/error.xml.builder
+++ b/app/views/oaisys/pmh/error.xml.builder
@@ -1,30 +1,4 @@
-if error_code == :badArgument
-  xml.push_deferred_attribute('xmlns': 'http://www.openarchives.org/OAI/2.0/',
-                              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-                              'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
-                              'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd')
-else
-  xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
-                              'xmlns:oai-id': 'http://www.openarchives.org/OAI/2.0/oai-identifier',
-                              'xmlns': 'http://www.openarchives.org/OAI/2.0/',
-                              'xmlns:etd_ms': 'http://www.ndltd.org/standards/metadata/etdms/1.0/',
-                              'xmlns:atom': 'http://www.w3.org/2005/Atom',
-                              'xmlns:rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
-                              'xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-                              'xmlns:dcterms': 'http://purl.org/dc/terms/',
-                              'xmlns:oreatom': 'http://www.openarchives.org/ore/atom/',
-                              'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-                              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-                              'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
-                              'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd '\
-                              'http://www.openarchives.org/OAI/2.0/oai-identifier '\
-                              'http://www.openarchives.org/OAI/2.0/oai-identifier.xsd '\
-                              'http://www.openarchives.org/OAI/2.0/oai_dc/ '\
-                              'http://www.openarchives.org/OAI/2.0/oai_dc.xsd '\
-                              'http://www.ndltd.org/standards/metadata/etdms/1.0/ '\
-                              'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
-                              'http://www.w3.org/2005/Atom')
-end
+xml.push_deferred_attribute(error_header(error_code))
 
 xml.tag!('request', parameters)
 xml.error(error_message, code: error_code)

--- a/app/views/oaisys/pmh/list_identifiers.xml.builder
+++ b/app/views/oaisys/pmh/list_identifiers.xml.builder
@@ -21,11 +21,11 @@ xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
 
 xml.tag!('request', parameters, 'https://era.library.ualberta.ca/oai')
 xml.ListIdentifiers do
-  results.each do |result|
+  identifiers.each do |identifier|
     xml.tag!('header') do
-      xml.identifier 'oai:era.library.ualberta.ca:' + result.id
-      xml.datestamp result.record_created_at.utc.xmlschema
-      result.member_of_paths.each do |set|
+      xml.identifier 'oai:era.library.ualberta.ca:' + identifier[0]
+      xml.datestamp identifier[1].utc.xmlschema
+      identifier[2].each do |set|
         xml.setSpec set.tr('/', ':')
       end
     end

--- a/app/views/oaisys/pmh/list_identifiers.xml.builder
+++ b/app/views/oaisys/pmh/list_identifiers.xml.builder
@@ -21,11 +21,11 @@ xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
 
 xml.tag!('request', parameters, 'https://era.library.ualberta.ca/oai')
 xml.ListIdentifiers do
-  identifiers.each do |identifier|
+  identifiers.each do |identifier, date, sets|
     xml.tag!('header') do
-      xml.identifier 'oai:era.library.ualberta.ca:' + identifier[0]
-      xml.datestamp identifier[1].utc.xmlschema
-      identifier[2].each do |set|
+      xml.identifier 'oai:era.library.ualberta.ca:' + identifier
+      xml.datestamp date.utc.xmlschema
+      sets.each do |set|
         xml.setSpec set.tr('/', ':')
       end
     end

--- a/app/views/oaisys/pmh/list_identifiers.xml.builder
+++ b/app/views/oaisys/pmh/list_identifiers.xml.builder
@@ -19,13 +19,15 @@ xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
                             'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
                             'http://www.w3.org/2005/Atom')
 
-xml.tag!('request', parameters.to_unsafe_h, 'https://era.library.ualberta.ca/oai')
-xml.tag!('ListMetadataFormats') do
-  supported_formats.each do |supported_format|
-    xml.tag!('metadataFormat') do
-      xml.metadataPrefix supported_format[:metadataPrefix]
-      xml.schema supported_format[:schema]
-      xml.metadataNamespace supported_format[:metadataNamespace]
+xml.tag!('request', parameters, 'https://era.library.ualberta.ca/oai')
+xml.ListIdentifiers do
+  results.each do |result|
+    xml.tag!('header') do
+      xml.identifier 'oai:era.library.ualberta.ca:' + result.id
+      xml.datestamp result.record_created_at.utc.xmlschema
+      result.member_of_paths.each do |set|
+        xml.setSpec set.tr('/', ':')
+      end
     end
   end
 end

--- a/app/views/oaisys/pmh/list_metadata_formats.xml.builder
+++ b/app/views/oaisys/pmh/list_metadata_formats.xml.builder
@@ -19,7 +19,7 @@ xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
                             'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
                             'http://www.w3.org/2005/Atom')
 
-xml.tag!('request', parameters.to_unsafe_h, 'https://era.library.ualberta.ca/oai')
+xml.tag!('request', parameters, 'https://era.library.ualberta.ca/oai')
 xml.tag!('ListMetadataFormats') do
   supported_formats.each do |supported_format|
     xml.tag!('metadataFormat') do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,5 @@
 en:
   error_messages:
     illegal_or_missing_arguments: 'The request includes illegal arguments or is missing required arguments.'
+    unavailable_metadata_format: 'Unavailable metadata format'
+    no_record_found: 'No record found'

--- a/lib/oaisys.rb
+++ b/lib/oaisys.rb
@@ -4,7 +4,4 @@ module Oaisys
   require 'oaisys/bad_argument_error'
   require 'oaisys/cannot_disseminate_format_error'
   require 'oaisys/no_records_match_error'
-
-  # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
-  ActionController::Parameters.action_on_unpermitted_parameters = :raise
 end

--- a/lib/oaisys.rb
+++ b/lib/oaisys.rb
@@ -3,4 +3,6 @@ require 'oaisys/engine'
 module Oaisys
   require 'oaisys/pmh_error'
   require 'oaisys/bad_argument_error'
+  require 'oaisys/cannot_disseminate_format_error'
+  require 'oaisys/no_records_match_error'
 end

--- a/lib/oaisys.rb
+++ b/lib/oaisys.rb
@@ -1,6 +1,5 @@
-require 'oaisys/engine'
-
 module Oaisys
+  require 'oaisys/engine'
   require 'oaisys/pmh_error'
   require 'oaisys/bad_argument_error'
   require 'oaisys/cannot_disseminate_format_error'

--- a/lib/oaisys.rb
+++ b/lib/oaisys.rb
@@ -4,4 +4,7 @@ module Oaisys
   require 'oaisys/bad_argument_error'
   require 'oaisys/cannot_disseminate_format_error'
   require 'oaisys/no_records_match_error'
+
+  # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
+  ActionController::Parameters.action_on_unpermitted_parameters = :raise
 end

--- a/lib/oaisys/cannot_disseminate_format_error.rb
+++ b/lib/oaisys/cannot_disseminate_format_error.rb
@@ -1,4 +1,4 @@
-class Oaisys::BadArgumentError < Oaisys::PMHError
+class Oaisys::CannotDisseminateFormatError < Oaisys::PMHError
 
   attr_reader :parameters
 
@@ -7,11 +7,11 @@ class Oaisys::BadArgumentError < Oaisys::PMHError
   end
 
   def error_code
-    :badArgument
+    :cannotDisseminateFormat
   end
 
   def error_message
-    I18n.t('error_messages.illegal_or_missing_arguments')
+    I18n.t('error_messages.unavailable_metadata_format')
   end
 
 end

--- a/lib/oaisys/no_records_match_error.rb
+++ b/lib/oaisys/no_records_match_error.rb
@@ -1,4 +1,4 @@
-class Oaisys::BadArgumentError < Oaisys::PMHError
+class Oaisys::NoRecordsMatchError < Oaisys::PMHError
 
   attr_reader :parameters
 
@@ -7,11 +7,11 @@ class Oaisys::BadArgumentError < Oaisys::PMHError
   end
 
   def error_code
-    :badArgument
+    :noRecordsMatch
   end
 
   def error_message
-    I18n.t('error_messages.illegal_or_missing_arguments')
+    I18n.t('error_messages.no_record_found')
   end
 
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -32,5 +32,8 @@ module Dummy
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
+    config.action_controller.action_on_unpermitted_parameters = :raise
+
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -32,8 +32,5 @@ module Dummy
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
-    ActionController::Parameters.action_on_unpermitted_parameters = :raise
-
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -32,5 +32,8 @@ module Dummy
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
+    ActionController::Parameters.action_on_unpermitted_parameters = :raise
+
   end
 end

--- a/test/integration/expect_args_test.rb
+++ b/test/integration/expect_args_test.rb
@@ -6,6 +6,8 @@ class ExpectArgsTest < ActionDispatch::IntegrationTest
 
   setup do
     @routes = Oaisys::Engine.routes
+    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
+    ActionController::Parameters.action_on_unpermitted_parameters = :raise
   end
 
   def test_unexpected_arg_xml

--- a/test/integration/expect_args_test.rb
+++ b/test/integration/expect_args_test.rb
@@ -6,8 +6,6 @@ class ExpectArgsTest < ActionDispatch::IntegrationTest
 
   setup do
     @routes = Oaisys::Engine.routes
-    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
-    ActionController::Parameters.action_on_unpermitted_parameters = :raise
   end
 
   def test_unexpected_arg_xml

--- a/test/integration/list_metadata_formats_test.rb
+++ b/test/integration/list_metadata_formats_test.rb
@@ -6,8 +6,6 @@ class ListMetadataFormatsTest < ActionDispatch::IntegrationTest
 
   setup do
     @routes = Oaisys::Engine.routes
-    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
-    ActionController::Parameters.action_on_unpermitted_parameters = :raise
   end
 
   def test_list_metadata_formats_xml

--- a/test/integration/list_metadata_formats_test.rb
+++ b/test/integration/list_metadata_formats_test.rb
@@ -6,6 +6,8 @@ class ListMetadataFormatsTest < ActionDispatch::IntegrationTest
 
   setup do
     @routes = Oaisys::Engine.routes
+    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
+    ActionController::Parameters.action_on_unpermitted_parameters = :raise
   end
 
   def test_list_metadata_formats_xml


### PR DESCRIPTION
## Context

Need to be able to handle list identifiers verb

Related to ch101

## What's New

Added two new errors. Now using parameters for errors as they (or a subset of them) are sometimes displayed. Expect args now no longer needs a verb parameter. Now handles list identifier response other than from, until, and resumptionToken arguments.
