### PR TITLE
Handle to and from arguments for ListIdentifiers [ch106]

### DIFF
--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -54,6 +54,8 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   def list_identifiers
     expect_args for_verb: :ListIdentifiers, required: [:metadataPrefix], optional: [:from, :until, :set],
                 exclusive: [:resumptionToken]
+    results = results.record_created_from(params[:from]) if params[:from].present?
+    results = results.record_created_until(params[:until]) if params[:until].present?
   end
 
   private

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -53,7 +53,7 @@ class Oaisys::PMHController < Oaisys::ApplicationController
 
   # TODO: Handle resumptionToken argument.
   def list_identifiers
-    parameters = expect_args for_verb: :ListIdentifiers, required: [:metadataPrefix], optional: [:from, :until, :set],
+    parameters = expect_args required: [:metadataPrefix], optional: [:from, :until, :set],
                              exclusive: [:resumptionToken]
 
     public_items_params = { verb: parameters[:verb], format: parameters[:metadataPrefix] }

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -54,8 +54,8 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   def list_identifiers
     expect_args for_verb: :ListIdentifiers, required: [:metadataPrefix], optional: [:from, :until, :set],
                 exclusive: [:resumptionToken]
-    results = results.record_created_from(params[:from]) if params[:from].present?
-    results = results.record_created_until(params[:until]) if params[:until].present?
+    results = results.created_on_or_after(params[:from]) if params[:from].present?
+    results = results.created_on_or_before(params[:until]) if params[:until].present?
   end
 
   private

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -93,9 +93,9 @@ class Oaisys::PMHController < Oaisys::ApplicationController
             end
 
     model = model.public_items
-    model = model.public_items.belongs_to_path(restricted_to_set.tr(':', '/')) unless restricted_to_set.nil?
-    model = model.created_on_or_after(from_date) unless from_date.nil?
-    model = model.created_on_or_before(until_date) unless until_date.nil?
+    model = model.public_items.belongs_to_path(restricted_to_set.tr(':', '/')) if restricted_to_set.present?
+    model = model.created_on_or_after(from_date) if from_date.present?
+    model = model.created_on_or_before(until_date) if until_date.present?
 
     model
   end


### PR DESCRIPTION
## Context

To and from args are now handled

Related to ch106

## What's New

Results are now limited if to and from are provided by using record_created_from/until scopes
