### PR TITLE
Create tests for list identifiers response [ch111]

### DIFF
--- a/test/integration/list_identifiers_test.rb
+++ b/test/integration/list_identifiers_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ListIdentifiersTest < ActionDispatch::IntegrationTest
+
+  include Oaisys::Engine.routes.url_helpers
+
+  setup do
+    @routes = Oaisys::Engine.routes
+  end
+
+  def test_cannot_disseminate_format_xml
+    get oaisys_path(verb: 'ListIdentifiers', metadataPrefix: 'nasty'), headers: { 'Accept' => 'application/xml' }
+    assert_response :success
+
+    schema = Nokogiri::XML::Schema(File.open(file_fixture('OAI-PMH.xsd')))
+    document = Nokogiri::XML(@response.body)
+    assert_empty schema.validate(document)
+
+    assert_select 'OAI-PMH' do
+      assert_select 'responseDate'
+      assert_select 'request'
+      assert_select 'error', I18n.t('error_messages.unavailable_metadata_format')
+    end
+  end
+
+end

--- a/test/integration/list_identifiers_test.rb
+++ b/test/integration/list_identifiers_test.rb
@@ -6,8 +6,6 @@ class ListIdentifiersTest < ActionDispatch::IntegrationTest
 
   setup do
     @routes = Oaisys::Engine.routes
-    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
-    ActionController::Parameters.action_on_unpermitted_parameters = :raise
   end
 
   def test_cannot_disseminate_format_xml

--- a/test/integration/list_identifiers_test.rb
+++ b/test/integration/list_identifiers_test.rb
@@ -6,6 +6,8 @@ class ListIdentifiersTest < ActionDispatch::IntegrationTest
 
   setup do
     @routes = Oaisys::Engine.routes
+    # Set an action on unpermitted parameters to raise an exception, used to validate parameters.
+    ActionController::Parameters.action_on_unpermitted_parameters = :raise
   end
 
   def test_cannot_disseminate_format_xml


### PR DESCRIPTION
## Context

Need tests for list identifiers response

Related to ch111

## What's New

Added test for cannot disseminate format... the rest of the tests need to be in Jupiter (in a separate PR) because they rely on Jupiter's models.