### PR TITLE
Open Rails dependency up for Rails 6

### DIFF
--- a/oaisys.gemspec
+++ b/oaisys.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_dependency 'builder', '~> 3.0'
-  spec.add_dependency 'rails', '~> 5.2.3'
+  spec.add_dependency 'rails', '>= 5.2.3'
 
   spec.add_dependency 'pg'
   spec.add_dependency 'rubocop'


### PR DESCRIPTION
## Context

Fixes this in jupiter:
```
Resolving dependencies....
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    rails (~> 6.0.2)

    oaisys was resolved to 0.1.0, which depends on
      rails (~> 5.2.3)
```

Related to https://github.com/ualbertalib/jupiter/issues/1430

## What's New

Open up dependency required for rails to include rails 6+

