### PR TITLE
GetRecord verb implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 # RDF stuff
-gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', ref: '5914f26eba2238f62044bdd3776e1961a8422bd7'
+gem 'acts_as_rdfable', github: 'ualbertalib/acts_as_rdfable', ref: '37915a9581713524f95f28425a10fdfee4335d06'
 gem 'builder_deferred_tagging', github: 'ualbertalib/builder_deferred_tagging', tag: 'v0.01'

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 # RDF stuff
-gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', tag: 'v0.01'
+gem 'acts_as_rdfable', github: 'mbarnett/acts_as_rdfable', ref: '5914f26eba2238f62044bdd3776e1961a8422bd7'
 gem 'builder_deferred_tagging', github: 'ualbertalib/builder_deferred_tagging', tag: 'v0.01'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
     oaisys (0.1.0)
       builder (~> 3.0)
       pg
-      rails (~> 5.2.3)
+      rails (>= 5.2.3)
       rubocop
       rubocop-performance
       rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/mbarnett/acts_as_rdfable.git
-  revision: d1d3b79cab1f074976407e42f9e28d24de5131c8
-  tag: v0.01
+  revision: 5914f26eba2238f62044bdd3776e1961a8422bd7
+  ref: 5914f26eba2238f62044bdd3776e1961a8422bd7
   specs:
-    acts_as_rdfable (0.1.0)
-      rails (~> 5.2.3)
+    acts_as_rdfable (0.2.1)
+      rails (>= 5.2.3)
 
 GIT
   remote: https://github.com/ualbertalib/builder_deferred_tagging.git
@@ -174,4 +174,4 @@ DEPENDENCIES
   pry
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -139,6 +139,7 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   def model_for_verb_format(verb:, format:)
     model = ActsAsRdfable.known_classes_for(format: format).first
     raise Oaisys::CannotDisseminateError.new(parameters: { verb: verb, metadataPrefix: format }) if model.blank?
+
     model
   end
 

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -47,7 +47,17 @@ class Oaisys::PMHController < Oaisys::ApplicationController
   # get_record is referring to the verb, not a getter.
   # rubocop:disable Naming/AccessorMethodName
   def get_record
-    expect_args required: [:identifier, :metadataPrefix]
+    params = expect_args required: [:identifier, :metadataPrefix]
+
+    metadata_format = params[:metadataPrefix]
+    # TODO: grab record model by looking up prefix...
+    item = Item.find(params[:identifier])
+
+    respond_to do |format|
+      format.xml do
+        render :get_record, locals: {item: item, metadata_format: metadata_format}
+      end
+    end
   end
   # rubocop:enable Naming/AccessorMethodName
 

--- a/app/jobs/oaisys/application_job.rb
+++ b/app/jobs/oaisys/application_job.rb
@@ -1,2 +1,0 @@
-class Oaisys::ApplicationJob < ActiveJob::Base
-end

--- a/app/mailers/oaisys/application_mailer.rb
+++ b/app/mailers/oaisys/application_mailer.rb
@@ -1,6 +1,0 @@
-class Oaisys::ApplicationMailer < ActionMailer::Base
-
-  default from: 'from@example.com'
-  layout 'mailer'
-
-end

--- a/app/models/oaisys/application_record.rb
+++ b/app/models/oaisys/application_record.rb
@@ -1,5 +1,0 @@
-class Oaisys::ApplicationRecord < ActiveRecord::Base
-
-  self.abstract_class = true
-
-end

--- a/app/views/oaisys/pmh/get_record.xml.builder
+++ b/app/views/oaisys/pmh/get_record.xml.builder
@@ -1,0 +1,35 @@
+xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
+                            'xmlns:oai-id': 'http://www.openarchives.org/OAI/2.0/oai-identifier',
+                            'xmlns': 'http://www.openarchives.org/OAI/2.0/',
+                            'xmlns:etd_ms': 'http://www.ndltd.org/standards/metadata/etdms/1.0/',
+                            'xmlns:atom': 'http://www.w3.org/2005/Atom',
+                            'xmlns:rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+                            'xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+                            'xmlns:dcterms': 'http://purl.org/dc/terms/',
+                            'xmlns:oreatom': 'http://www.openarchives.org/ore/atom/',
+                            'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+                            'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                            'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
+                            'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd '\
+                            'http://www.openarchives.org/OAI/2.0/oai-identifier '\
+                            'http://www.openarchives.org/OAI/2.0/oai-identifier.xsd '\
+                            'http://www.openarchives.org/OAI/2.0/oai_dc/ '\
+                            'http://www.openarchives.org/OAI/2.0/oai_dc.xsd '\
+                            'http://www.ndltd.org/standards/metadata/etdms/1.0/ '\
+                            'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
+                            'http://www.w3.org/2005/Atom')
+
+xml.tag!('request', 'https://era.library.ualberta.ca/oai', verb: 'GetRecord', metadataPrefix: metadata_format, identifier: item.id,)
+
+xml.GetRecord do |get_record|
+  get_record.record do |record|
+    record.header do |header|
+      header.identifier "oai:era.library.ualberta.ca:#{item.id}"
+      header.datestamp item.updated_at
+      item.member_of_paths.each {|path| header.setSpec path.tr('/', ':')}
+    end
+    record.metadata do |metadata_xml|
+      item.serialize_metadata(format: metadata_format, into_document: metadata_xml)
+    end
+  end
+end

--- a/app/views/oaisys/pmh/get_record.xml.builder
+++ b/app/views/oaisys/pmh/get_record.xml.builder
@@ -19,14 +19,15 @@ xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
                             'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
                             'http://www.w3.org/2005/Atom')
 
-xml.tag!('request', 'https://era.library.ualberta.ca/oai', verb: 'GetRecord', metadataPrefix: metadata_format, identifier: item.id,)
+xml.tag!('request', 'https://era.library.ualberta.ca/oai', verb: 'GetRecord', metadataPrefix: metadata_format,
+                                                           identifier: item.id)
 
 xml.GetRecord do |get_record|
   get_record.record do |record|
     record.header do |header|
       header.identifier "oai:era.library.ualberta.ca:#{item.id}"
       header.datestamp item.updated_at
-      item.member_of_paths.each {|path| header.setSpec path.tr('/', ':')}
+      item.member_of_paths.each { |path| header.setSpec path.tr('/', ':') }
     end
     record.metadata do |metadata_xml|
       item.serialize_metadata(format: metadata_format, into_document: metadata_xml)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,4 @@ en:
     no_verb: 'Verb is required'
     unavailable_metadata_format: 'Unavailable metadata format'
     no_record_found: 'No record found'
+    id_does_not_exist: 'No matching identifier'

--- a/lib/oaisys/engine.rb
+++ b/lib/oaisys/engine.rb
@@ -1,4 +1,3 @@
-
 class Oaisys::Engine < ::Rails::Engine
 
   isolate_namespace Oaisys

--- a/lib/oaisys/engine.rb
+++ b/lib/oaisys/engine.rb
@@ -1,3 +1,4 @@
+
 class Oaisys::Engine < ::Rails::Engine
 
   isolate_namespace Oaisys

--- a/lib/oaisys/id_does_not_exist_error.rb
+++ b/lib/oaisys/id_does_not_exist_error.rb
@@ -1,4 +1,4 @@
-class Oaisys::CannotDisseminateError < Oaisys::PMHError
+class Oaisys::IdDoesNotExist < Oaisys::PMHError
 
   attr_reader :parameters
 
@@ -7,11 +7,11 @@ class Oaisys::CannotDisseminateError < Oaisys::PMHError
   end
 
   def error_code
-    :cannotDisseminateFormat
+    :idDoesNotExist
   end
 
   def error_message
-    I18n.t('error_messages.unavailable_metadata_format')
+    I18n.t('error_messages.id_does_not_exist')
   end
 
 end


### PR DESCRIPTION
## Context

Implementing the GetRecord verb, which necessitates integrating with new rendering features in ActsAsRDFable.

## What's New

- Adds an implementation of GetRecord.
- Adds IDDoesNotExist error handling
- Refactors `public_items_for_metadata_format` now that we no longer need to do any hard-coding of knowledge of format->class mappings in either the engine or the host app.

## Not Included

- I'm going to submit another PR for tests for the verb, since it needs to add infrastructure to mock out the decorators, and I need to figure out what the best approach for that is.