### PR TITLE
Implement ListRecords Verb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/mbarnett/acts_as_rdfable.git
-  revision: 5914f26eba2238f62044bdd3776e1961a8422bd7
-  ref: 5914f26eba2238f62044bdd3776e1961a8422bd7
+  remote: https://github.com/ualbertalib/acts_as_rdfable.git
+  revision: 37915a9581713524f95f28425a10fdfee4335d06
+  ref: 37915a9581713524f95f28425a10fdfee4335d06
   specs:
     acts_as_rdfable (0.2.1)
       rails (>= 5.2.3)

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -99,7 +99,7 @@ class Oaisys::PMHController < Oaisys::ApplicationController
                          exclusive: [:resumptionToken]
 
     # Note the order here is critical: check whether or not we retrieved a page based on a resumption token
-    # haven been handed to the API, and if we were not, start the results on page 1
+    # haven't been handed to the API, and if we were not, start the results on page 1
     resumption_token_provided = params[:page].present?
     params[:page] = 1 if params[:page].blank?
 

--- a/app/controllers/oaisys/pmh_controller.rb
+++ b/app/controllers/oaisys/pmh_controller.rb
@@ -91,7 +91,7 @@ class Oaisys::PMHController < Oaisys::ApplicationController
       end
     end
   end
-  # rubocop:enable Naming/AccessorMethodName]
+  # rubocop:enable Naming/AccessorMethodName
 
   # TODO: Handle from, until, and resumptionToken arguments.
   def list_identifiers

--- a/app/views/oaisys/pmh/list_records.xml.builder
+++ b/app/views/oaisys/pmh/list_records.xml.builder
@@ -1,0 +1,37 @@
+xml.push_deferred_attribute('xmlns:dc': 'http://purl.org/dc/elements/1.1/',
+                            'xmlns:oai-id': 'http://www.openarchives.org/OAI/2.0/oai-identifier',
+                            'xmlns': 'http://www.openarchives.org/OAI/2.0/',
+                            'xmlns:etd_ms': 'http://www.ndltd.org/standards/metadata/etdms/1.0/',
+                            'xmlns:atom': 'http://www.w3.org/2005/Atom',
+                            'xmlns:rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+                            'xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+                            'xmlns:dcterms': 'http://purl.org/dc/terms/',
+                            'xmlns:oreatom': 'http://www.openarchives.org/ore/atom/',
+                            'xmlns:oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+                            'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                            'xsi:schemaLocation': 'http://www.openarchives.org/OAI/2.0/ '\
+                            'http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd '\
+                            'http://www.openarchives.org/OAI/2.0/oai-identifier '\
+                            'http://www.openarchives.org/OAI/2.0/oai-identifier.xsd '\
+                            'http://www.openarchives.org/OAI/2.0/oai_dc/ '\
+                            'http://www.openarchives.org/OAI/2.0/oai_dc.xsd '\
+                            'http://www.ndltd.org/standards/metadata/etdms/1.0/ '\
+                            'http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd '\
+                            'http://www.w3.org/2005/Atom')
+
+xml.tag!('request', 'https://era.library.ualberta.ca/oai', parameters)
+
+xml.ListRecords do |list_records|
+  items.each do |item|
+    list_records.record do |record|
+      record.header do |header|
+        header.identifier "oai:era.library.ualberta.ca:#{item.id}"
+        header.datestamp item.updated_at
+        item.member_of_paths.each { |path| header.setSpec path.tr('/', ':') }
+      end
+      record.metadata do |metadata_xml|
+        item.serialize_metadata(format: metadata_format, into_document: metadata_xml)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Implementing the ListRecords verb.

## What's New

- Adds an implementation of ListRecords.
- Refactors `list_identifiers` to extract logic for (conditionally) restricting queries to a specific model/data-range with pagination support into a new method, `query_params_from_api_params`, which is also now used by `list_records`

## Not Included

- Id support for ListMetadataFormats is up next, followed by building out some decorator infrastructure to build tests around this