### PR TITLE
don't throw an error when initializing

### DIFF
--- a/lib/oaisys/redis_connection.rb
+++ b/lib/oaisys/redis_connection.rb
@@ -9,7 +9,6 @@ class Oaisys::RedisConnection
 
   def initialize(redis_url: Oaisys::Engine.config.redis_url)
     @redis = Redis.new(url: redis_url)
-    raise ConnectionError unless connected?
   end
 
   def create_token(parameters:, verb:, identifier:)


### PR DESCRIPTION
## Context

Shouldn't be throwing an error if we cant connect to redis when initializing the class. In jupiter we call this in an initializer https://github.com/ualbertalib/jupiter/blob/05f6c0b0fa67139040f2c6e0a7126c00d0bef09b/config/initializers/oaisys.rb#L14.  When we're precompiling assets for the Docker container this error is thrown because Redis isn't started/available.

We check for connection in every other instance method and raise a ConnectionError there so we should be okay (seems like redis gem does something similar, doesn't check in initialization but checks when you actually try to do something with redis).

Related to https://github.com/ualbertalib/jupiter/pull/1761

## What's New

Doesn't raise an error in initialize.