### PR TITLE
Reference newest acts_as_rdfable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ualbertalib/acts_as_rdfable.git
-  revision: 6020ba89d9f29992e85463078bc397092e487871
+  revision: 6b224060a90743ff20ab924510d3c9dd53149280
   tag: v0.2.4
   specs:
     acts_as_rdfable (0.2.1)


### PR DESCRIPTION
removed and added the same tag in acts_as_rdfable, didn't realise that the gemfile keeps a reference of the commit.